### PR TITLE
Updated to 1.5.1 and enabled on_member_x events through intents

### DIFF
--- a/gamesdenbot.py
+++ b/gamesdenbot.py
@@ -33,8 +33,10 @@ greetings = []
 with open(BASE_PATH + 'greetings.txt', 'r') as f:
     greetings = f.read().split(';\n')
 
-client = commands.Bot(command_prefix = '!')
+intents = discord.Intents.default() # Needed to enable recieving updates on member join/leave
+intents.members = True
 
+client = commands.Bot(command_prefix = '!', intents=intents)
 
 # list of roles
 roles = {


### PR DESCRIPTION
Discord's API has been updated to 1.5.1, which has lead to some changes on how certain events work. Specifically, Intents are now a thing, which controls how the bot monitors certain events. Check out [this](https://discordpy.readthedocs.io/en/latest/intents.html) link for the official documentation. In case you don't want to read that, there are a few steps to do.

* Update discord.py to 1.5.1 using pip install --upgrade discord.py
* Go to the [Discord Developer Portal](https://discord.com/developers/applications), go to your app, to the bot button on the left, and scroll down, check "Server members intent". It should be under Privileged Gateway Intents.
* Accept this pull request